### PR TITLE
Client ID Registration: QA feedback

### DIFF
--- a/app/components/organizations/api-client-registration-form.hbs
+++ b/app/components/organizations/api-client-registration-form.hbs
@@ -4,12 +4,12 @@
 		<h4>Thank you for registering!</h4>
 		<p>
 			We have sent an email to <strong>{{this.email}}</strong> containing your client ID. 
-			This email was sent from support@ror.org with the subject "ROR API client ID".
+			This email was sent from api@ror.org with the subject "ROR API client ID".
 		</p>
 		<p class="mb-0">
 			If you do not receive this email within 15 minutes, check your spam/junk folder. 
 			If you still cannot find this email, please contact 
-			<a href="mailto:support@ror.org">support@ror.org</a>.
+			<a href="mailto:api@ror.org">api@ror.org</a>.
 		</p>
 		</div>
 	{{else if this.showErrorMessage}}
@@ -17,7 +17,7 @@
 			<h4 class="alert-heading">Registration Error</h4>
 			<p>
 				Oh no, there was an error and we were not able to process your request for a ROR API client ID. 
-				Please contact <a href="mailto:support@ror.org">support@ror.org</a> for assistance.
+				Please contact <a href="mailto:api@ror.org">api@ror.org</a> for assistance.
 			</p>
       <button 
         type="button" 

--- a/app/templates/organizations/api-client-id.hbs
+++ b/app/templates/organizations/api-client-id.hbs
@@ -12,8 +12,8 @@
         <ul>
           <li>ROR client IDs are not used for authentication or authorization, and are therefore not secret and can be sent as plain text.</li>
           <li>We do not provide a way to recover or revoke a lost client ID. If you lose track of your client ID, please register a new client ID.</li>
-          <li>For more information about ROR API client IDs, see <a href="https://ror.readme.io/XXXXX">https://ror.readme.io/XXXXX</a></li>
-          <li>For additional help obtaining or using a ROR API client ID contact <a href="mailto:support@ror.org">support@ror.org</a></li>
+          <li>For more information about ROR API client IDs, see <a href="https://ror.readme.io/docs/client-id">https://ror.readme.io/docs/client-id</a></li>
+          <li>For additional help obtaining or using a ROR API client ID contact <a href="mailto:api@ror.org">api@ror.org</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
- Set [api@ror.org](mailto:api@ror.org) as the sending address for the client ID registration  confirmation email
- On the registration form, in the text "For more information about ROR API client IDs, see https://ror.readme.io/XXXXX", replace the placeholder link with https://ror.readme.io/docs/client-id 
- In the registration form success message, in the sentence beginning  “This email was sent from [support@ror.org](mailto:support@ror.org)….” change the email address to [api@ror.org](mailto:api@ror.org).