### PR TITLE
Adds default subject and body to mailto in footer

### DIFF
--- a/app/templates/components/application-socials.hbs
+++ b/app/templates/components/application-socials.hbs
@@ -1,7 +1,7 @@
 <section class="section section-socials" data-background-color="light-grey">
 	<div class="container">
 		<div class="row justify-content-between no-gutters ml-auto mr-auto text-center">
-			<div class="col-sm-6 col-md"><a href="mailto:info@ror.org"><i class="fa-solid fa-envelope"></i>
+			<div class="col-sm-6 col-md"><a href="mailto:info@ror.org?subject=Question%20about%20the%20Research%20Organization%20Registry&body=Dear%20Research%20Organization%20Registry%20%28ROR%29%2C%20" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-envelope"></i>
 				<span>Email</span></a>
 			</div>
 			<div class="col-sm-6 col-md"><a href="https://www.linkedin.com/company/ror-research-organization-registry/"><i class="fa-brands fa-linkedin"></i>

--- a/app/templates/components/application-socials.hbs
+++ b/app/templates/components/application-socials.hbs
@@ -1,7 +1,7 @@
 <section class="section section-socials" data-background-color="light-grey">
 	<div class="container">
 		<div class="row justify-content-between no-gutters ml-auto mr-auto text-center">
-			<div class="col-sm-6 col-md"><a href="mailto:info@ror.org?subject=Question%20about%20the%20Research%20Organization%20Registry&body=Dear%20Research%20Organization%20Registry%20%28ROR%29%2C%20" target="_blank"><i class="fa-solid fa-envelope"></i>
+			<div class="col-sm-6 col-md"><a href="mailto:support@ror.org?subject=Question%20about%20the%20Research%20Organization%20Registry&body=Dear%20Research%20Organization%20Registry%20%28ROR%29%2C%20" target="_blank"><i class="fa-solid fa-envelope"></i>
 				<span>Email</span></a>
 			</div>
 			<div class="col-sm-6 col-md"><a href="https://www.linkedin.com/company/ror-research-organization-registry/" target="_blank"><i class="fa-brands fa-linkedin"></i>

--- a/app/templates/components/application-socials.hbs
+++ b/app/templates/components/application-socials.hbs
@@ -1,25 +1,25 @@
 <section class="section section-socials" data-background-color="light-grey">
 	<div class="container">
 		<div class="row justify-content-between no-gutters ml-auto mr-auto text-center">
-			<div class="col-sm-6 col-md"><a href="mailto:info@ror.org?subject=Question%20about%20the%20Research%20Organization%20Registry&body=Dear%20Research%20Organization%20Registry%20%28ROR%29%2C%20" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-envelope"></i>
+			<div class="col-sm-6 col-md"><a href="mailto:info@ror.org?subject=Question%20about%20the%20Research%20Organization%20Registry&body=Dear%20Research%20Organization%20Registry%20%28ROR%29%2C%20" target="_blank"><i class="fa-solid fa-envelope"></i>
 				<span>Email</span></a>
 			</div>
-			<div class="col-sm-6 col-md"><a href="https://www.linkedin.com/company/ror-research-organization-registry/"><i class="fa-brands fa-linkedin"></i>
+			<div class="col-sm-6 col-md"><a href="https://www.linkedin.com/company/ror-research-organization-registry/" target="_blank"><i class="fa-brands fa-linkedin"></i>
 				<span>LinkedIn</span></a>
 			</div>
-			<div class="col-sm-6 col-md"><a href="https://mastodon.social/@ResearchOrgs"><i class="fa-brands fa-mastodon"></i>
+			<div class="col-sm-6 col-md"><a href="https://mastodon.social/@ResearchOrgs" target="_blank"><i class="fa-brands fa-mastodon"></i>
 				<span>Mastodon</span></a>
 			</div>
-			<div class="col-sm-6 col-md"><a href="https://bsky.app/profile/researchorgs.bsky.social"><i class="fa-brands fa-bluesky"></i>
+			<div class="col-sm-6 col-md"><a href="https://bsky.app/profile/researchorgs.bsky.social" target="_blank"><i class="fa-brands fa-bluesky"></i>
 				<span>Bluesky</span></a>
 			</div>
-			<div class="col-sm-6 col-md"><a href="https://www.youtube.com/channel/UCQBOpOpW-JEKoVCUlmCK1Eg"><i class="fa-brands fa-youtube"></i>
+			<div class="col-sm-6 col-md"><a href="https://www.youtube.com/channel/UCQBOpOpW-JEKoVCUlmCK1Eg" target="_blank"><i class="fa-brands fa-youtube"></i>
 				<span>YouTube</span></a>
 			</div>
-			<div class="col-sm-6 col-md"><a href="https://github.com/ror-community"><i class="fa-brands fa-github"></i>
+			<div class="col-sm-6 col-md"><a href="https://github.com/ror-community" target="_blank"><i class="fa-brands fa-github"></i>
 				<span>GitHub</span></a>
 			</div>
-			<div class="col-sm-6 col-md"><a href="https://ror.readme.io/"><i class="fa-solid fa-book"></i>
+			<div class="col-sm-6 col-md"><a href="https://ror.readme.io/" target="_blank"><i class="fa-solid fa-book"></i>
 				<span>Documentation</span></a>
 			</div>
 		</div>


### PR DESCRIPTION
We get emails at info at ror dot org from people who think we are a hospital or university, and I think they may be finding a ROR record via a search engine and then scrolling down and clicking the "Email" icon in the footer of the ROR app to email us. Have added a default subject line and body greeting in the mailto: link in the footer in hopes of 1) signaling to people that ROR is not the org they are looking for and 2) letting me know where they are finding our email address. This matches a [change recently implemented on ror-site](https://github.com/ror-community/ror-site/commit/0fa88247105385523d6c5d399ba3173d3730e03b). 